### PR TITLE
feat: add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"


### PR DESCRIPTION
[Closes #37]

## Description

Add `.github/dependabot.yml` configuration file to enable automatic monitoring and updating of GitHub Actions in workflow files. This configuration sets up weekly checks for action updates with separate PRs for each update.

## Changes Made

- Created `.github/dependabot.yml` with GitHub Actions package ecosystem configuration
- Configured weekly update schedule (Monday 09:00 UTC) for predictable PR timing
- Set directory to `/` to monitor all workflow files in `.github/workflows/`
- Used standard Dependabot configuration schema v2

## Acceptance Criteria & Testing

- [x] `.github/dependabot.yml` file is created with correct YAML format
- [x] Configuration specifies `github-actions` as the package ecosystem
- [x] Directory is set to `/` to monitor all workflow files in `.github/workflows/`
- [x] Update schedule is set to weekly
- [x] Configuration is committed to the main branch (via this PR)
- [x] File follows standard Dependabot configuration schema

Additional validation performed:
- [x] YAML syntax validated using Ruby parser
- [x] Configuration structure matches GitHub documentation
- [x] File location follows GitHub standard (`.github/dependabot.yml`)

## Notes

This implementation enables Dependabot to automatically detect GitHub Actions in the existing workflow files (`ci.yml`, `claude.yml`, and the `setup-environment` composite action) and create pull requests when newer versions are available. The weekly schedule balances staying current with avoiding PR fatigue.

Once this configuration is active, Dependabot will begin monitoring the pinned SHA references (like `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955`) and propose updates to newer versions while maintaining the security-focused pinning approach.